### PR TITLE
fix: return type warning

### DIFF
--- a/lavat.c
+++ b/lavat.c
@@ -273,6 +273,7 @@ short next_color(short current){
       return colors[(i+1)%8];
     }
   }
+  return colors[0];
 }
 
 void fix_rim_color(){


### PR DESCRIPTION
```text
lavat.c:276:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
  276 | }
      | ^
1 warning generated.
```